### PR TITLE
fixed status code bug

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tamatsuu <tamatsuu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:31:55 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/04 22:00:10 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2025/01/11 10:34:28 by tamatsuu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,6 +42,7 @@ typedef struct s_context {
 	int		pre_in_pipe_fd;
 	int		cnt;
 	bool	is_exec_in_child_ps;
+	bool	is_in_round_bracket;
 	int		last_status;
 	t_map	*env;
 }	t_context;

--- a/srcs/execution/execute.c
+++ b/srcs/execution/execute.c
@@ -6,7 +6,7 @@
 /*   By: tamatsuu <tamatsuu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/15 01:57:54 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/04 03:19:24 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2025/01/11 10:32:47 by tamatsuu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,12 +83,18 @@ int	exec_builtin(char *cmd, char **argv, t_context *ctx)
 int	exec_cmd(t_node *node, t_context *ctx)
 {
 	//signal();
-	expand_handler(node, ctx);
 	//redirect();
 	char	*cmd_path;
+	int		ret;
 
+	expand_handler(node, ctx);
 	if (is_builtin(node->cmds[0]))
-		return (exec_builtin(node->cmds[0], node->cmds, ctx));
+	{
+		ret = exec_builtin(node->cmds[0], node->cmds, ctx);
+		if (ctx->is_exec_in_child_ps)
+			exit(ret);
+		return (ret);
+	}
 	else
 	{
 		cmd_path = resolve_executable_path(node, ctx->env);

--- a/srcs/execution/execute_logical_operator.c
+++ b/srcs/execution/execute_logical_operator.c
@@ -6,7 +6,7 @@
 /*   By: tamatsuu <tamatsuu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/15 01:56:20 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/05 00:57:07 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2025/01/11 10:36:37 by tamatsuu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,8 @@ int	exec_or_node(t_node *node, t_context *ctx)
 	}
 	else
 	{
-		ctx->is_exec_in_child_ps = false;
+		if (!ctx->is_in_round_bracket)
+			ctx->is_exec_in_child_ps = false;
 		clear_pid_status(ctx);
 		return (exec_handler(node->right, ctx));
 	}
@@ -52,7 +53,8 @@ int	exec_and_node(t_node *node, t_context *ctx)
 	}
 	else
 	{
-		ctx->is_exec_in_child_ps = false;
+		if (!ctx->is_in_round_bracket)
+			ctx->is_exec_in_child_ps = false;
 		clear_pid_status(ctx);
 		return (exec_handler(node->right, ctx));
 	}
@@ -61,10 +63,12 @@ int	exec_and_node(t_node *node, t_context *ctx)
 int	exec_round_brackets(t_node *node, t_context *ctx)
 {
 	ctx->is_exec_in_child_ps = true;
+	ctx->is_in_round_bracket = true;
 	ctx->last_status = exec_handler(node->left, ctx);
 	if (ctx->cnt)
 		wait_children_status(ctx);
 	clear_pid_status(ctx);
+	ctx->is_in_round_bracket = false;
 	ctx->is_exec_in_child_ps = false;
 	return (ctx->last_status);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tamatsuu <tamatsuu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:36:46 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/08 21:52:31 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/11 10:34:59 by tamatsuu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,18 +83,19 @@ t_context	*init_ctx(void)
 	ret->pre_in_pipe_fd = -1;
 	ret->cnt = 0;
 	ret->is_exec_in_child_ps = false;
+	ret->is_in_round_bracket = false;
 	ret->last_status = 0;
 	return (ret);
 }
 
-void    clear_ctx(t_context *ctx)
+void	clear_ctx(t_context *ctx)
 {
-    if (!ctx)
-        d_throw_error("clear_ctx", "ctx is null");
-    ctx->in_pipe_fd = -1;
-    ctx->out_pipe_fd = -1;
-    ctx->pre_in_pipe_fd = -1;
-    ctx->cnt = 0;
-    ctx->is_exec_in_child_ps = false;
-    // ctx->last_status = 0;
+	if (!ctx)
+		d_throw_error("clear_ctx", "ctx is null");
+	ctx->in_pipe_fd = -1;
+	ctx->out_pipe_fd = -1;
+	ctx->pre_in_pipe_fd = -1;
+	ctx->cnt = 0;
+	ctx->is_exec_in_child_ps = false;
+	ctx->is_in_round_bracket = false;
 }


### PR DESCRIPTION

概要
コマンドに失敗した後 echo $? でステータスを確認すると、ステータスコードがリセットされる。
また、`(echo $? && exit 2) || echo $?` の挙動が、本家と異なる。

期待する動作
`(echo $? |&& exit 2) || echo $?` にて 0\n2\nが表示される
コマンド失敗後に $? に適切なエラーステータスが保持される

`exit 3  || echo 3`
上記の場合は、終了するため echo は実行されない

再現手順 (バグの場合)
`echo $? && exit 2) || echo $?`
`exit 3  || echo 3`

スクリーンショット・ログ (あれば)
関連するコード
main.c
execute 部

関連  issue 
#61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for tracking round bracket execution context in shell operations

- **Bug Fixes**
	- Improved handling of built-in command return values during execution
	- Enhanced logical operator processing with new context tracking mechanism

- **Refactor**
	- Updated execution context management to support more complex command scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->