### PR TITLE
Feature/signal heredoc/22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/10/25 21:34:48 by shokosoeno        #+#    #+#              #
-#    Updated: 2025/01/18 15:58:46 by ssoeno           ###   ########.fr        #
+#    Updated: 2025/01/19 15:28:29 by ssoeno           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -82,6 +82,7 @@ srcs/execution/execute_builtin.c \
 srcs/execution/execute_error.c \
 srcs/execution/execute_search_path_env.c \
 srcs/heredoc/heredoc.c \
+srcs/heredoc/heredoc_read.c \
 srcs/redirect/redirect.c \
 srcs/redirect/redirect_utils.c \
 get_next_line/get_next_line.c \

--- a/combination_test/run_test.sh
+++ b/combination_test/run_test.sh
@@ -38,9 +38,9 @@ else
 	echo "builtin test"
 	./combination_test/builtin_test.sh
 	test_result
-	echo "heredoc test"
-	./combination_test/heredoc_test.sh
-	test_result
+	# echo "heredoc test"
+	# ./combination_test/heredoc_test.sh
+	# test_result
 	echo "redirect test"
 	./combination_test/redirect_test.sh
 	test_result

--- a/combination_test/run_test.sh
+++ b/combination_test/run_test.sh
@@ -38,9 +38,9 @@ else
 	echo "builtin test"
 	./combination_test/builtin_test.sh
 	test_result
-	# echo "heredoc test"
-	# ./combination_test/heredoc_test.sh
-	# test_result
+	echo "heredoc test"
+	./combination_test/heredoc_test.sh
+	test_result
 	echo "redirect test"
 	./combination_test/redirect_test.sh
 	test_result

--- a/includes/heredoc.h
+++ b/includes/heredoc.h
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/06 13:31:55 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/19 00:55:33 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 15:29:24 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,10 @@
 # include "./minishell.h"
 # include "./parser.h"
 
-int		input_heredoc_content(char *eof, t_context *ctx);
+// heredoc_read.c
+int		read_heredoc(char *eof, t_context *ctx);
+
+// heredoc.c
 void	heredoc_handler(t_node *node, t_context *ctx);
 void	call_heredoc(t_node *node, t_context *ctx);
 bool	is_heredoc_end(char **redirects);

--- a/includes/heredoc.h
+++ b/includes/heredoc.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tamatsuu <tamatsuu@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/06 13:31:55 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/11 03:38:43 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2025/01/19 00:55:33 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,9 +15,9 @@
 # include "./minishell.h"
 # include "./parser.h"
 
-int		input_heredoc_content(char *eof);
-void	heredoc_handler(t_node *node);
-void	call_heredoc(t_node *node);
+int		input_heredoc_content(char *eof, t_context *ctx);
+void	heredoc_handler(t_node *node, t_context *ctx);
+void	call_heredoc(t_node *node, t_context *ctx);
 bool	is_heredoc_end(char **redirects);
 void	close_unused_fds(int *arry, size_t end);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:31:55 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/11 10:34:28 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2025/01/19 01:01:00 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,10 +46,11 @@ typedef struct s_context {
 	int		last_status;
 	int		stored_stdin;
 	int		stored_stdout;
+	bool	heredoc_interrupted;
 	t_map	*env;
 }	t_context;
 
-void		start_exec(char *line, t_context *ctx);
+int		start_exec(char *line, t_context *ctx);
 t_context	*init_ctx(void);
 void		clear_ctx(t_context *ctx);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:31:55 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/19 01:01:00 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 15:54:20 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ typedef struct s_context {
 	t_map	*env;
 }	t_context;
 
-int		start_exec(char *line, t_context *ctx);
+void		start_exec(char *line, t_context *ctx);
 t_context	*init_ctx(void);
 void		clear_ctx(t_context *ctx);
 

--- a/includes/signals.h
+++ b/includes/signals.h
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/30 21:49:29 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/05 15:06:15 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/18 18:39:39 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,9 +24,10 @@ extern volatile sig_atomic_t	g_sig;
 void	set_idle_sig_handlers(void);
 void	set_parent_sig_handlers(void);
 void	set_child_sig_handlers(void);
+void	check_core_dump(int status);
 
 bool	is_interactive_mode(void);
-int	    sigint_event_hook(void);
-void	check_core_dump(int status);
+int		sigint_event_hook(void);
+int		heredoc_sigint_event_hook(void);
 
 #endif

--- a/srcs/execution/execute.c
+++ b/srcs/execution/execute.c
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/15 01:57:54 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/18 18:06:32 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 15:48:33 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,6 @@
 #include "../includes/environment.h"
 #include "../includes/expand.h"
 #include "../includes/redirect.h"
-
-// int exec_redirect(t_node *node, t_context *ctx);
 
 int	exec_handler(t_node *ast_node, t_context *ctx)
 {
@@ -40,11 +38,6 @@ int	exec_handler(t_node *ast_node, t_context *ctx)
 		return (EXIT_FAILURE);
 }
 
-// int exec_redirect(t_node *node, t_context *ctx)
-// {
-// 	ctx->last_status = apply_redirects(node);
-// 	return (ctx->last_status);
-// }
 int	exec_pipe(t_node *node, t_context *ctx)
 {
 	int	pfd[2];
@@ -60,12 +53,15 @@ int	exec_pipe(t_node *node, t_context *ctx)
 
 int	exec_cmd(t_node *node, t_context *ctx)
 {
+	int	ret;
+
+	ret = 0;
 	expand_handler(node, ctx);
 	if (node->left && node->left->redirects)
 		set_redirect_fds(node);
 	if (is_builtin(node->cmds[0]))
 	{
-		int ret = run_builtin(node, ctx);
+		ret = run_builtin(node, ctx);
 		if (ret != EXIT_SUCCESS && ctx->is_exec_in_child_ps)
 			d_throw_error("exec_cmd", "builtin execution failed");
 		return (ret);

--- a/srcs/execution/execute_external.c
+++ b/srcs/execution/execute_external.c
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/31 02:54:58 by ssoeno            #+#    #+#             */
-/*   Updated: 2025/01/18 18:16:44 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 15:33:38 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,7 @@ static bool	verify_direct_path_or_exit(char *cmd)
 	struct stat	st;
 
 	if (!cmd)
-		d_throw_error("verify_direct_path", "cmd is NULL\n"); // alreadly checked in resolve_executable_path?
+		d_throw_error("verify_direct_path", "cmd is NULL\n");
 	if (access(cmd, F_OK) != 0)
 	{
 		if (errno == EACCES)

--- a/srcs/heredoc/heredoc.c
+++ b/srcs/heredoc/heredoc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tamatsuu <tamatsuu@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/05 02:14:42 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/19 05:45:00 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2025/01/19 15:18:54 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,17 +16,72 @@
 #include "../includes/heredoc.h"
 #include "../includes/signals.h"
 
-static int terminate_heredoc(char *line, int *pipe_fds);
+static int	terminate_heredoc(int *pipe_fds);
+int			read_heredoc_line(char *eof, int pipe_fd, t_context *ctx);
+
+// int	input_heredoc_content(char *eof, t_context *ctx)
+// {
+// 	char			*line;
+// 	int				pipe_fds[2];
+
+// 	line = NULL;
+// 	if (isatty(STDIN_FILENO))
+// 		rl_event_hook = heredoc_sigint_event_hook;
+// 	if (pipe(pipe_fds) == -1)
+// 		d_throw_error("input_heredoc_content", "pipe failed");
+// 	while (1)
+// 	{
+// 		free(line);
+// 		line = NULL;
+// 		line = readline("> ");
+// 		if (g_sig == SIGINT)
+// 		{
+// 			ctx->heredoc_interrupted = true;
+// 			return (terminate_heredoc(line, pipe_fds));
+// 		}
+// 		if (line == NULL || \
+// 		(ft_strlen(line) == ft_strlen(eof) && !ft_strcmp(eof, line)))
+// 			break ;
+// 		else
+// 		{
+// 			write(pipe_fds[1], line, ft_strlen(line));
+// 			write(pipe_fds[1], "\n", ft_strlen("\n"));
+// 		}
+// 	}
+// 	if (isatty(STDIN_FILENO))
+// 		rl_event_hook = sigint_event_hook;
+// 	free(line);
+// 	close(pipe_fds[1]);
+// 	return (pipe_fds[0]);
+// }
+/*
+by returning pipe_fds[0], we can redirect STDIN from this pipe
+so that the command reads these lines as input.
+*/
 
 int	input_heredoc_content(char *eof, t_context *ctx)
 {
-	char			*line;
-	int				pipe_fds[2];
+	int	pipe_fds[2];
+	int	ret;
 
-	line = NULL;
-	rl_event_hook = heredoc_sigint_event_hook;
+	if (isatty(STDIN_FILENO))
+		rl_event_hook = heredoc_sigint_event_hook;
 	if (pipe(pipe_fds) == -1)
 		d_throw_error("input_heredoc_content", "pipe failed");
+	ret = read_heredoc_line(eof, pipe_fds[1], ctx);
+	if (isatty(STDIN_FILENO))
+		rl_event_hook = sigint_event_hook;
+	close(pipe_fds[1]);
+	if (ret < 0)
+		return (terminate_heredoc(pipe_fds));
+	return (pipe_fds[0]);
+}
+
+int	read_heredoc_line(char *eof, int pipe_fd, t_context *ctx)
+{
+	char	*line;
+
+	line = NULL;
 	while (1)
 	{
 		free(line);
@@ -35,32 +90,24 @@ int	input_heredoc_content(char *eof, t_context *ctx)
 		if (g_sig == SIGINT)
 		{
 			ctx->heredoc_interrupted = true;
-			return (terminate_heredoc(line, pipe_fds));
+			free (line);
+			return (-2);
 		}
 		if (line == NULL || \
 		(ft_strlen(line) == ft_strlen(eof) && !ft_strcmp(eof, line)))
 			break ;
-		else
-		{
-			write(pipe_fds[1], line, ft_strlen(line));
-			write(pipe_fds[1], "\n", ft_strlen("\n"));
-		}
+		write(pipe_fd, line, ft_strlen(line));
+		write(pipe_fd, "\n", ft_strlen("\n"));
 	}
-	rl_event_hook = sigint_event_hook;
 	free(line);
-	close(pipe_fds[1]);
-	return (pipe_fds[0]);
+	return (EXIT_SUCCESS);
 }
-/*
-by returning pipe_fds[0], we can redirect STDIN from this pipe
-so that the command reads these lines as input.
-*/
 
-static int terminate_heredoc(char *line, int *pipe_fds)
+static int terminate_heredoc(int *pipe_fds)
 {
 	close(pipe_fds[1]);
-	free(line);
-	//rl_event_hook = sigint_event_hook;
+	if (isatty(STDIN_FILENO))
+		rl_event_hook = sigint_event_hook;
 	return (-2);
 }
 

--- a/srcs/heredoc/heredoc.c
+++ b/srcs/heredoc/heredoc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tamatsuu <tamatsuu@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/05 02:14:42 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/19 01:01:46 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 05:45:00 by tamatsuu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,7 @@ static int terminate_heredoc(char *line, int *pipe_fds)
 {
 	close(pipe_fds[1]);
 	free(line);
-	rl_event_hook = sigint_event_hook;
+	//rl_event_hook = sigint_event_hook;
 	return (-2);
 }
 

--- a/srcs/heredoc/heredoc.c
+++ b/srcs/heredoc/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/05 02:14:42 by tamatsuu          #+#    #+#             */
-/*   Updated: 2025/01/19 15:18:54 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 15:27:55 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,101 +15,6 @@
 #include <unistd.h>
 #include "../includes/heredoc.h"
 #include "../includes/signals.h"
-
-static int	terminate_heredoc(int *pipe_fds);
-int			read_heredoc_line(char *eof, int pipe_fd, t_context *ctx);
-
-// int	input_heredoc_content(char *eof, t_context *ctx)
-// {
-// 	char			*line;
-// 	int				pipe_fds[2];
-
-// 	line = NULL;
-// 	if (isatty(STDIN_FILENO))
-// 		rl_event_hook = heredoc_sigint_event_hook;
-// 	if (pipe(pipe_fds) == -1)
-// 		d_throw_error("input_heredoc_content", "pipe failed");
-// 	while (1)
-// 	{
-// 		free(line);
-// 		line = NULL;
-// 		line = readline("> ");
-// 		if (g_sig == SIGINT)
-// 		{
-// 			ctx->heredoc_interrupted = true;
-// 			return (terminate_heredoc(line, pipe_fds));
-// 		}
-// 		if (line == NULL || \
-// 		(ft_strlen(line) == ft_strlen(eof) && !ft_strcmp(eof, line)))
-// 			break ;
-// 		else
-// 		{
-// 			write(pipe_fds[1], line, ft_strlen(line));
-// 			write(pipe_fds[1], "\n", ft_strlen("\n"));
-// 		}
-// 	}
-// 	if (isatty(STDIN_FILENO))
-// 		rl_event_hook = sigint_event_hook;
-// 	free(line);
-// 	close(pipe_fds[1]);
-// 	return (pipe_fds[0]);
-// }
-/*
-by returning pipe_fds[0], we can redirect STDIN from this pipe
-so that the command reads these lines as input.
-*/
-
-int	input_heredoc_content(char *eof, t_context *ctx)
-{
-	int	pipe_fds[2];
-	int	ret;
-
-	if (isatty(STDIN_FILENO))
-		rl_event_hook = heredoc_sigint_event_hook;
-	if (pipe(pipe_fds) == -1)
-		d_throw_error("input_heredoc_content", "pipe failed");
-	ret = read_heredoc_line(eof, pipe_fds[1], ctx);
-	if (isatty(STDIN_FILENO))
-		rl_event_hook = sigint_event_hook;
-	close(pipe_fds[1]);
-	if (ret < 0)
-		return (terminate_heredoc(pipe_fds));
-	return (pipe_fds[0]);
-}
-
-int	read_heredoc_line(char *eof, int pipe_fd, t_context *ctx)
-{
-	char	*line;
-
-	line = NULL;
-	while (1)
-	{
-		free(line);
-		line = NULL;
-		line = readline("> ");
-		if (g_sig == SIGINT)
-		{
-			ctx->heredoc_interrupted = true;
-			free (line);
-			return (-2);
-		}
-		if (line == NULL || \
-		(ft_strlen(line) == ft_strlen(eof) && !ft_strcmp(eof, line)))
-			break ;
-		write(pipe_fd, line, ft_strlen(line));
-		write(pipe_fd, "\n", ft_strlen("\n"));
-	}
-	free(line);
-	return (EXIT_SUCCESS);
-}
-
-static int terminate_heredoc(int *pipe_fds)
-{
-	close(pipe_fds[1]);
-	if (isatty(STDIN_FILENO))
-		rl_event_hook = sigint_event_hook;
-	return (-2);
-}
 
 void	heredoc_handler(t_node *node, t_context *ctx)
 {
@@ -137,7 +42,7 @@ void	call_heredoc(t_node *node, t_context *ctx)
 	{
 		if (!ft_strcmp(node->redirects[i], "<<") && node->redirects[i + 1])
 		{
-			temp_fd_arry[j++] = input_heredoc_content(node->redirects[i + 1], ctx);
+			temp_fd_arry[j++] = read_heredoc(node->redirects[i + 1], ctx);
 			i++;
 		}
 		i++;

--- a/srcs/heredoc/heredoc_read.c
+++ b/srcs/heredoc/heredoc_read.c
@@ -1,0 +1,72 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   heredoc_read.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/05 02:14:42 by tamatsuu          #+#    #+#             */
+/*   Updated: 2025/01/19 15:32:04 by ssoeno           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+#include "../includes/utils.h"
+#include <unistd.h>
+#include "../includes/heredoc.h"
+#include "../includes/signals.h"
+
+static int	terminate_heredoc(int *pipe_fds);
+static int	read_heredoc_line(char *eof, int pipe_fd, t_context *ctx);
+
+int	read_heredoc(char *eof, t_context *ctx)
+{
+	int	pipe_fds[2];
+	int	ret;
+
+	if (isatty(STDIN_FILENO))
+		rl_event_hook = heredoc_sigint_event_hook;
+	if (pipe(pipe_fds) == -1)
+		d_throw_error("read_heredoc", "pipe failed");
+	ret = read_heredoc_line(eof, pipe_fds[1], ctx);
+	if (isatty(STDIN_FILENO))
+		rl_event_hook = sigint_event_hook;
+	close(pipe_fds[1]);
+	if (ret < 0)
+		return (terminate_heredoc(pipe_fds));
+	return (pipe_fds[0]);
+}
+
+int	read_heredoc_line(char *eof, int pipe_fd, t_context *ctx)
+{
+	char	*line;
+
+	line = NULL;
+	while (1)
+	{
+		free(line);
+		line = NULL;
+		line = readline("> ");
+		if (g_sig == SIGINT)
+		{
+			ctx->heredoc_interrupted = true;
+			free (line);
+			return (-2);
+		}
+		if (line == NULL || \
+		(ft_strlen(line) == ft_strlen(eof) && !ft_strcmp(eof, line)))
+			break ;
+		write(pipe_fd, line, ft_strlen(line));
+		write(pipe_fd, "\n", ft_strlen("\n"));
+	}
+	free(line);
+	return (EXIT_SUCCESS);
+}
+
+static int	terminate_heredoc(int *pipe_fds)
+{
+	close(pipe_fds[1]);
+	if (isatty(STDIN_FILENO))
+		rl_event_hook = sigint_event_hook;
+	return (-2);
+}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:36:46 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/19 14:26:24 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 15:54:01 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,7 +73,7 @@ int	main(int argc, char *argv[], char *envp[])
 	return (ctx->last_status);
 }
 
-int	start_exec(char *line, t_context *ctx)
+void	start_exec(char *line, t_context *ctx)
 {
 	t_token		*token_list;
 	t_node		*ast_node;
@@ -92,7 +92,6 @@ int	start_exec(char *line, t_context *ctx)
 	free_token_list(token_list);
 	free_ast(&ast_node);
 	close_stored_fds(ctx);
-	return (0);
 }
 
 void close_stored_fds(t_context *ctx)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tamatsuu <tamatsuu@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:36:46 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/19 05:51:03 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2025/01/19 13:43:30 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,10 +47,7 @@ int	main(int argc, char *argv[], char *envp[])
 			g_sig = 0;
 			ctx->last_status = 130;
 			rl_event_hook = sigint_event_hook;
-			continue ;            ctx->heredoc_interrupted = false;
-            g_sig = 0;
-            ctx->last_status = 130;
-            continue ;
+			continue ;
 		}
 		line = readline("minishell$ ");
 		if (line == NULL)
@@ -79,7 +76,6 @@ int	start_exec(char *line, t_context *ctx)
 	token_list = lexer(line);
 	ast_node = parse_cmd(&token_list);
 	clear_ctx(ctx);
-
 	heredoc_handler(ast_node, ctx);
 	exec_handler(ast_node, ctx);
 	// restore fds?

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:36:46 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/19 13:43:30 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 14:26:24 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,8 +46,13 @@ int	main(int argc, char *argv[], char *envp[])
 			ctx->heredoc_interrupted = false;
 			g_sig = 0;
 			ctx->last_status = 130;
-			rl_event_hook = sigint_event_hook;
-			continue ;
+			if (isatty(STDIN_FILENO))
+			{
+				rl_event_hook = sigint_event_hook;
+				continue ;
+			} else {
+				break;
+			}
 		}
 		line = readline("minishell$ ");
 		if (line == NULL)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tamatsuu <tamatsuu@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 21:36:46 by shokosoeno        #+#    #+#             */
-/*   Updated: 2025/01/19 01:52:47 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 05:51:03 by tamatsuu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ void close_stored_fds(t_context *ctx);
 
 int	main(int argc, char *argv[], char *envp[])
 {
-	char	*line;
+	char		*line;
 	t_context	*ctx;
 
 	ctx = init_ctx();
@@ -41,15 +41,16 @@ int	main(int argc, char *argv[], char *envp[])
 	while (1)
 	{
 		set_idle_sig_handlers();
-		printf("DEBUG %d\n", g_sig);
 		if (ctx->heredoc_interrupted == true)
 		{
-			// ft_putchar_fd('\n', STDOUT_FILENO);
-			rl_replace_line("", 0);
-			rl_on_new_line();
-			rl_redisplay();
 			ctx->heredoc_interrupted = false;
-			continue ;
+			g_sig = 0;
+			ctx->last_status = 130;
+			rl_event_hook = sigint_event_hook;
+			continue ;            ctx->heredoc_interrupted = false;
+            g_sig = 0;
+            ctx->last_status = 130;
+            continue ;
 		}
 		line = readline("minishell$ ");
 		if (line == NULL)
@@ -78,6 +79,7 @@ int	start_exec(char *line, t_context *ctx)
 	token_list = lexer(line);
 	ast_node = parse_cmd(&token_list);
 	clear_ctx(ctx);
+
 	heredoc_handler(ast_node, ctx);
 	exec_handler(ast_node, ctx);
 	// restore fds?

--- a/srcs/signal/signal_hook.c
+++ b/srcs/signal/signal_hook.c
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/24 13:41:50 by ssoeno            #+#    #+#             */
-/*   Updated: 2025/01/05 14:01:49 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/01/19 01:14:31 by ssoeno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,15 @@ int	sigint_event_hook(void)
 		rl_replace_line("", 0);
 		rl_on_new_line();
 		rl_redisplay();
+		rl_done = true;
+	}
+	return (EXIT_SUCCESS);
+}
+
+int	heredoc_sigint_event_hook(void)
+{
+	if (g_sig == SIGINT)
+	{
 		rl_done = true;
 	}
 	return (EXIT_SUCCESS);


### PR DESCRIPTION
ヒアドク中にCtrl Cを押すと入力プロンプトに戻る状態。
ただし、テストコードを実行すると無限ループに入ってしまう。mainループとは別の部分に問題があるようだが、特定できていないため、ヒアドクのテストをコメントアウトしていったんプッシュ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced heredoc handling with improved signal management
  - Added context tracking for heredoc interruptions
  - Introduced new functions for reading heredoc input and managing EOF conditions

- **Bug Fixes**
  - Improved error handling and signal interruption management during heredoc processing

- **Refactor**
  - Updated function signatures to support more robust context tracking
  - Modified execution flow to handle heredoc interruptions more gracefully
  - Removed deprecated functions related to redirection handling

- **Chores**
  - Updated author attributions across multiple files
  - Cleaned up unused code sections
  - Added new source file for heredoc reading functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->